### PR TITLE
Delete default security group creation.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,29 +298,6 @@ resource "aws_iam_instance_profile" "ec2" {
   role = aws_iam_role.ec2.name
 }
 
-resource "aws_security_group" "default" {
-  name        = module.label.id
-  description = "Allow inbound traffic from provided Security Groups"
-
-  vpc_id = var.vpc_id
-
-  ingress {
-    from_port       = 0
-    to_port         = 0
-    protocol        = -1
-    security_groups = var.allowed_security_groups
-  }
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  tags = module.label.tags
-}
-
 locals {
   // Remove `Name` tag from the map of tags because Elastic Beanstalk generates the `Name` tag automatically
   // and if it is provided, terraform tries to recreate the application on each `plan/apply`
@@ -534,7 +511,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "SecurityGroups"
-    value     = join(",", compact(concat([aws_security_group.default.id], var.additional_security_groups)))
+    value     = join(",", compact(var.additional_security_groups))
   }
 
   setting {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,11 +13,6 @@ output "name" {
   description = "Name"
 }
 
-output "security_group_id" {
-  value       = aws_security_group.default.id
-  description = "Security group id"
-}
-
 output "elb_zone_id" {
   value       = var.alb_zone_id[var.region]
   description = "ELB zone id"


### PR DESCRIPTION
It's conflicting with VPC one, and we don't use it at all.

```
Error: Error creating Security Group: InvalidGroup.Duplicate: The security group 'botbit-staging-main' already exists for VPC 'vpc-0b368cec381d33d19'
	status code: 400, request id: 3d89b442-26e5-468c-829f-055f14f3fc1e

  on .terraform/modules/elastic_beanstalk_environment.elastic_beanstalk_environment/main.tf line 301, in resource "aws_security_group" "default":
 301: resource "aws_security_group" "default" {
```